### PR TITLE
GDBackend:  default_quality: 80

### DIFF
--- a/mysite/_config/config.yml
+++ b/mysite/_config/config.yml
@@ -10,7 +10,7 @@ SSViewer:
 MySQLDatabase:
   connection_charset: 'utf8'
 GDBackend:
-  default_quality: 100
+  default_quality: 80
 SiteTree:
   nested_urls: true
 Email:


### PR DESCRIPTION
Lowering default image quality from 100 saves a lot of kb's
