### PR TITLE
composer change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"gdmedia/ss-auto-git-ignore": "*",
 		"bramdeleeuw/silverstripe-schema": "*",
 		"bramdeleeuw/silverstripe-pageslices": "*",
-		"bramdeleeuw/silverstripe-pageslices-userform": "dev-master",
+		"bramdeleeuw/silverstripe-pageslices-userform": "*",
 		"markguinn/silverstripe-email-helpers": "*",
 		"hubertusanton/silverstripe-seo": "*"
 	},


### PR DESCRIPTION
for ss 3.x "bramdeleeuw/silverstripe-pageslices-userform": "*" instead of 'dev/master'